### PR TITLE
Added new decorator

### DIFF
--- a/django_umami/core.py
+++ b/django_umami/core.py
@@ -53,7 +53,6 @@ class UmamiPayload:
     def dict(self):
         data = {"website": self.website}
         if self.data:
-            print("has data")
             data |= self.data
         return data
 
@@ -86,6 +85,10 @@ class Umami:
         if self.options.session:
             return self.options.session.post(url=f"{self.options.host_url}/api/send", json=data, headers=headers)
         return requests.post(url=f"{self.options.host_url}/api/send", json=data, headers=headers)
+
+    def track_event_name(self, event_name: str):
+        payload = UmamiPayload(website=self.options.website_id, data={"name": event_name})
+        return self.send(payload=payload)
 
     def track(self, event: UmamiEventData | str, event_data=None):
         website_id = self.options.website_id

--- a/django_umami/decorators.py
+++ b/django_umami/decorators.py
@@ -1,14 +1,41 @@
 from functools import wraps
+from typing import Optional
+
+from django.http import HttpRequest
 
 from django_umami.core import umami, UmamiEventData
 
 
-def track(event_name: str, event_data: UmamiEventData = None):
+def track(event: UmamiEventData | str, event_data: Optional[UmamiEventData] = None):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            umami.track(event_name, event_data)
+            umami.track(event, event_data)
             return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def track_visit(event_data: Optional[UmamiEventData] = None):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(request: HttpRequest, *args, **kwargs):
+            new_event_data: UmamiEventData = event_data or UmamiEventData()
+
+            data: UmamiEventData = UmamiEventData(
+                url=request.path,
+                referrer=request.META.get("HTTP_REFERER", ""),
+                title=request.META.get("HTTP_TITLE", ""),
+            )
+
+            new_event_data.update(
+                {k: v for k, v in data.items() if k not in new_event_data}
+            )  # type: ignore[typeddict-item]
+
+            umami.track(new_event_data)
+            return func(request, *args, **kwargs)
 
         return wrapper
 

--- a/django_umami/decorators.py
+++ b/django_umami/decorators.py
@@ -31,8 +31,8 @@ def track_visit(event_data: Optional[UmamiEventData] = None):
             )
 
             new_event_data.update(
-                {k: v for k, v in data.items() if k not in new_event_data}
-            )  # type: ignore[typeddict-item]
+                {k: v for k, v in data.items() if k not in new_event_data}  # type: ignore[typeddict-item]
+            )
 
             umami.track(new_event_data)
             return func(request, *args, **kwargs)


### PR DESCRIPTION
Added `track_visit` decorator to allow django view tracking. Can be used like below:

```py
import django_umami.decorators

@django_umami.decorators.track_visit()
def my_view(request: HttpRequest):
   pass
```

This extracts data such as: `url`, `referrer` and `title`. You can optionally add (and override) arguments with 
```py
@django_umami.decorators.track_visit({"url": "/abc"})
```